### PR TITLE
update

### DIFF
--- a/extensions/clone.lua
+++ b/extensions/clone.lua
@@ -1,0 +1,47 @@
+local dir = (arg[0]:match("^(.*[/\\])") or "")
+package.path = dir .. "?.lua;" .. package.path
+require("help").check(arg)
+
+io.write("Repository URL? ")
+local url = io.read():match("^%s*(.-)%s*$")
+
+if url == "" then
+    print("Error: URL is required.")
+    os.exit(1)
+end
+
+io.write("Folder name? (leave blank to use default) ")
+local folder = io.read():match("^%s*(.-)%s*$")
+
+local clone_cmd
+local target_dir
+
+if folder ~= "" then
+    clone_cmd = string.format("git clone %s %s", string.format("%q", url), string.format("%q", folder))
+    target_dir = folder
+else
+    -- derive folder name from URL (strip .git suffix and take last path segment)
+    target_dir = url:match("([^/]+)$"):gsub("%.git$", "")
+    clone_cmd = string.format("git clone %s", string.format("%q", url))
+end
+
+print("Cloning into '" .. target_dir .. "'...")
+local ok = os.execute(clone_cmd)
+
+if not ok then
+    print("Error: git clone failed.")
+    os.exit(1)
+end
+
+-- write a shell snippet that the toolbox runner can source to cd
+local cd_file = os.getenv("DEV_TOOLBOX_CD_FILE")
+if cd_file and cd_file ~= "" then
+    local f = io.open(cd_file, "w")
+    if f then
+        f:write(target_dir)
+        f:close()
+    end
+else
+    -- fallback: print so the user can cd manually
+    print("cd " .. target_dir)
+end

--- a/extensions/clone.yaml
+++ b/extensions/clone.yaml
@@ -1,0 +1,13 @@
+name: git-clone
+description: Clone a git repository and cd into it. Accepts a URL and an optional folder name.
+args:
+  - name: url
+    description: The git repository URL to clone
+    required: true
+    interactive: true
+  - name: folder
+    description: Optional folder name to clone into (defaults to repo name)
+    required: false
+    interactive: true
+commands:
+  - lua git-clone.lua

--- a/extensions/create-axum-justfile.lua
+++ b/extensions/create-axum-justfile.lua
@@ -1,3 +1,7 @@
+local dir = (arg[0]:match("^(.*[/\\])") or "")
+package.path = dir .. "?.lua;" .. package.path
+require("help").check(arg)
+
 local JUSTFILE_CONTENT = [=[# Alias
 alias install := install-deps
 alias config:= configure

--- a/extensions/create-justfile.lua
+++ b/extensions/create-justfile.lua
@@ -1,1 +1,5 @@
+local dir = (arg[0]:match("^(.*[/\\])") or "")
+package.path = dir .. "?.lua;" .. package.path
+require("help").check(arg)
+
 print("create a justfile in the present dir")

--- a/extensions/git-clone.lua
+++ b/extensions/git-clone.lua
@@ -1,2 +1,0 @@
-
--- clone a project an

--- a/extensions/help.lua
+++ b/extensions/help.lua
@@ -1,0 +1,63 @@
+local M = {}
+
+function M.check(args)
+    if not (args and args[1] == "--help") then return end
+
+    local script = args[0]:gsub("%.lua$", "")
+    local f = io.open(script .. ".yaml", "r")
+    if not f then
+        print("No docs found: " .. script .. ".yaml")
+        os.exit(0)
+    end
+
+    local lines = {}
+    for line in f:lines() do lines[#lines + 1] = line end
+    f:close()
+
+    local name, desc, args_list, cmds = "", "", {}, {}
+    local section, cur = nil, nil
+
+    for _, line in ipairs(lines) do
+        if line:match("^name:") then
+            name = line:match("^name:%s*(.*)")
+        elseif line:match("^description:") then
+            desc = line:match("^description:%s*(.*)")
+        elseif line:match("^args:") then
+            section = "args"
+        elseif line:match("^commands:") then
+            section = "commands"
+            cur = nil
+        elseif section == "args" then
+            local n = line:match("^  %- name:%s*(.*)")
+            if n then
+                cur = { name = n }
+                args_list[#args_list + 1] = cur
+            elseif cur then
+                local k, v = line:match("^    (%a+):%s*(.*)")
+                if k then cur[k] = v end
+            end
+        elseif section == "commands" then
+            local c = line:match("^  %- (.*)")
+            if c then cmds[#cmds + 1] = c end
+        end
+    end
+
+    print(name .. " -- " .. desc)
+
+    if #args_list > 0 then
+        print("\nARGUMENTS:")
+        for _, a in ipairs(args_list) do
+            local req = a.required == "true" and "[required]" or "[optional]"
+            print(string.format("  %-16s %s  %s", a.name, a.description or "", req))
+        end
+    end
+
+    if #cmds > 0 then
+        print("\nCOMMAND:")
+        for _, c in ipairs(cmds) do print("  " .. c) end
+    end
+
+    os.exit(0)
+end
+
+return M

--- a/extensions/test.lua
+++ b/extensions/test.lua
@@ -1,1 +1,5 @@
+local dir = (arg[0]:match("^(.*[/\\])") or "")
+package.path = dir .. "?.lua;" .. package.path
+require("help").check(arg)
+
 print("running a test lua script")

--- a/extensions/write-commit.lua
+++ b/extensions/write-commit.lua
@@ -1,4 +1,8 @@
-local commit_kinds = { feat = true, chore = true, refactor = true, update = true }
+local dir = (arg[0]:match("^(.*[/\\])") or "")
+package.path = dir .. "?.lua;" .. package.path
+require("help").check(arg)
+
+local commit_kinds = { feat = true, chore = true, refactor = true, update = true, lint = true }
 
 io.write("Commit kind? ")
 local kind = io.read():match("^%s*(.-)%s*$")
@@ -20,19 +24,4 @@ local commit_message = io.read():match("^%s*(.-)%s*$")
 local message = string.format("%s(%s):\n\n%s\n", kind, commit_title, commit_message)
 
 print(message)
-
-local pathspec = arg and arg[1]
-
-if pathspec then
-    os.execute("git add " .. pathspec)
-else
-    io.write("No pathspec given — stage all changes? [y/N] ")
-    local confirm = io.read():match("^%s*(.-)%s*$"):lower()
-    if confirm ~= "y" and confirm ~= "yes" then
-        print("Aborted. Pass a pathspec pattern (e.g. '*.rs' or 'src/') to stage specific files.")
-        os.exit(1)
-    end
-    os.execute("git add .")
-end
-
 os.execute("git commit -m " .. string.format("%q", message))


### PR DESCRIPTION
## Summary by Sourcery

Introduce a shared help system for Lua extensions and add a new git clone helper while simplifying commit staging.

New Features:
- Add a reusable help module that renders CLI help text from YAML definitions.
- Introduce a new git clone extension that clones repositories and instructs the toolbox runner to cd into the cloned directory.

Enhancements:
- Wire existing Lua extensions to the shared help module and adjust package search paths for local requires.
- Allow a new `lint` commit kind in the write-commit helper script.
- Remove automatic git add behavior from the write-commit script, leaving only commit message generation.

Documentation:
- Add YAML-based documentation for the git clone extension.